### PR TITLE
Store main key for key derivations from 512-bit BIP39 recovery code 

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -34,7 +34,7 @@ import org.koin.dsl.module
  * @author Steve Soltys
  * @author Torsten Grote
  */
-class App : Application() {
+open class App : Application() {
 
     private val appModule = module {
         single { SettingsManager(this@App) }
@@ -52,22 +52,7 @@ class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        startKoin {
-            androidLogger()
-            androidContext(this@App)
-            modules(
-                listOf(
-                    cryptoModule,
-                    headerModule,
-                    metadataModule,
-                    documentsProviderModule, // storage plugin
-                    backupModule,
-                    restoreModule,
-                    installModule,
-                    appModule
-                )
-            )
-        }
+        startKoin()
         if (isDebugBuild()) {
             StrictMode.setThreadPolicy(
                 StrictMode.ThreadPolicy.Builder()
@@ -86,6 +71,23 @@ class App : Application() {
         permitDiskReads {
             migrateTokenFromMetadataToSettingsManager()
         }
+    }
+
+    protected open fun startKoin() = startKoin {
+        androidLogger()
+        androidContext(this@App)
+        modules(
+            listOf(
+                cryptoModule,
+                headerModule,
+                metadataModule,
+                documentsProviderModule, // storage plugin
+                backupModule,
+                restoreModule,
+                installModule,
+                appModule
+            )
+        )
     }
 
     private val settingsManager: SettingsManager by inject()

--- a/app/src/main/java/com/stevesoltys/seedvault/crypto/CryptoModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/crypto/CryptoModule.kt
@@ -1,9 +1,19 @@
 package com.stevesoltys.seedvault.crypto
 
 import org.koin.dsl.module
+import java.security.KeyStore
+
+private const val ANDROID_KEY_STORE = "AndroidKeyStore"
 
 val cryptoModule = module {
     factory<CipherFactory> { CipherFactoryImpl(get()) }
-    single<KeyManager> { KeyManagerImpl() }
+    single<KeyManager> {
+        val keyStore by lazy {
+            KeyStore.getInstance(ANDROID_KEY_STORE).apply {
+                load(null)
+            }
+        }
+        KeyManagerImpl(keyStore)
+    }
     single<Crypto> { CryptoImpl(get(), get(), get()) }
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/recoverycode/RecoveryCodeViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/recoverycode/RecoveryCodeViewModel.kt
@@ -70,6 +70,7 @@ class RecoveryCodeViewModel(
         val seed = SeedCalculator(JavaxPBKDF2WithHmacSHA512.INSTANCE).calculateSeed(mnemonic, "")
         if (forVerifyingNewCode) {
             keyManager.storeBackupKey(seed)
+            keyManager.storeMainKey(seed)
             mRecoveryCodeSaved.setEvent(true)
         } else {
             mExistingCodeChecked.setEvent(crypto.verifyBackupKey(seed))

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/recoverycode/RecoveryCodeViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/recoverycode/RecoveryCodeViewModel.kt
@@ -73,7 +73,9 @@ class RecoveryCodeViewModel(
             keyManager.storeMainKey(seed)
             mRecoveryCodeSaved.setEvent(true)
         } else {
-            mExistingCodeChecked.setEvent(crypto.verifyBackupKey(seed))
+            val verified = crypto.verifyBackupKey(seed)
+            if (verified && !keyManager.hasMainKey()) keyManager.storeMainKey(seed)
+            mExistingCodeChecked.setEvent(verified)
         }
     }
 

--- a/app/src/sharedTest/java/com/stevesoltys/seedvault/crypto/KeyManagerTestImpl.kt
+++ b/app/src/sharedTest/java/com/stevesoltys/seedvault/crypto/KeyManagerTestImpl.kt
@@ -15,12 +15,24 @@ class KeyManagerTestImpl : KeyManager {
         throw NotImplementedError("not implemented")
     }
 
+    override fun storeMainKey(seed: ByteArray) {
+        throw NotImplementedError("not implemented")
+    }
+
     override fun hasBackupKey(): Boolean {
         return true
     }
 
+    override fun hasMainKey(): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
     override fun getBackupKey(): SecretKey {
         return key
+    }
+
+    override fun getMainKey(): SecretKey {
+        throw NotImplementedError("not implemented")
     }
 
 }

--- a/app/src/test/java/com/stevesoltys/seedvault/TestApp.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/TestApp.kt
@@ -1,0 +1,45 @@
+package com.stevesoltys.seedvault
+
+import com.stevesoltys.seedvault.crypto.CipherFactory
+import com.stevesoltys.seedvault.crypto.CipherFactoryImpl
+import com.stevesoltys.seedvault.crypto.Crypto
+import com.stevesoltys.seedvault.crypto.CryptoImpl
+import com.stevesoltys.seedvault.crypto.KeyManager
+import com.stevesoltys.seedvault.crypto.KeyManagerTestImpl
+import com.stevesoltys.seedvault.header.headerModule
+import com.stevesoltys.seedvault.metadata.metadataModule
+import com.stevesoltys.seedvault.plugins.saf.documentsProviderModule
+import com.stevesoltys.seedvault.restore.install.installModule
+import com.stevesoltys.seedvault.transport.backup.backupModule
+import com.stevesoltys.seedvault.transport.restore.restoreModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+
+class TestApp : App() {
+
+    private val testCryptoModule = module {
+        factory<CipherFactory> { CipherFactoryImpl(get()) }
+        single<KeyManager> { KeyManagerTestImpl() }
+        single<Crypto> { CryptoImpl(get(), get(), get()) }
+    }
+    private val appModule = module {
+        single { Clock() }
+    }
+
+    override fun startKoin() = startKoin {
+        androidContext(this@TestApp)
+        modules(
+            listOf(
+                testCryptoModule,
+                headerModule,
+                metadataModule,
+                documentsProviderModule, // storage plugin
+                backupModule,
+                restoreModule,
+                installModule,
+                appModule
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/stevesoltys/seedvault/crypto/KeyManagerImplTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/crypto/KeyManagerImplTest.kt
@@ -1,0 +1,65 @@
+package com.stevesoltys.seedvault.crypto
+
+import com.stevesoltys.seedvault.getRandomByteArray
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertArrayEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD
+import org.junit.jupiter.api.assertThrows
+import java.security.KeyStore
+
+@TestInstance(PER_METHOD)
+class KeyManagerImplTest {
+
+    private val keyStore: KeyStore = mockk()
+    private val keyManager = KeyManagerImpl(keyStore)
+
+    @Test
+    fun `31 byte seed gets rejected for backup key`() {
+        val seed = getRandomByteArray(31)
+        assertThrows<IllegalArgumentException> {
+            keyManager.storeBackupKey(seed)
+        }
+    }
+
+    @Test
+    fun `63 byte seed gets rejected for main key`() {
+        val seed = getRandomByteArray(63)
+        assertThrows<IllegalArgumentException> {
+            keyManager.storeMainKey(seed)
+        }
+    }
+
+    @Test
+    fun `32 byte seed gets accepted for backup key`() {
+        val seed = getRandomByteArray(32)
+        val keyEntry = slot<KeyStore.SecretKeyEntry>()
+
+        every { keyStore.setEntry(any(), capture(keyEntry), any()) } just Runs
+
+        keyManager.storeBackupKey(seed)
+
+        assertTrue(keyEntry.isCaptured)
+        assertArrayEquals(seed.sliceArray(0 until 32), keyEntry.captured.secretKey.encoded)
+    }
+
+    @Test
+    fun `64 byte seed gets accepted for main key`() {
+        val seed = getRandomByteArray(64)
+        val keyEntry = slot<KeyStore.SecretKeyEntry>()
+
+        every { keyStore.setEntry(any(), capture(keyEntry), any()) } just Runs
+
+        keyManager.storeMainKey(seed)
+
+        assertTrue(keyEntry.isCaptured)
+        assertArrayEquals(seed.sliceArray(32 until 64), keyEntry.captured.secretKey.encoded)
+    }
+
+}

--- a/app/src/test/java/com/stevesoltys/seedvault/metadata/MetadataManagerTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/metadata/MetadataManagerTest.kt
@@ -8,6 +8,7 @@ import android.content.pm.ApplicationInfo.FLAG_SYSTEM
 import android.content.pm.PackageInfo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stevesoltys.seedvault.Clock
+import com.stevesoltys.seedvault.TestApp
 import com.stevesoltys.seedvault.getRandomByteArray
 import com.stevesoltys.seedvault.getRandomString
 import com.stevesoltys.seedvault.metadata.PackageState.APK_AND_DATA
@@ -37,7 +38,10 @@ import kotlin.random.Random
 
 @Suppress("DEPRECATION")
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [29]) // robolectric does not support 30, yet
+@Config(
+    sdk = [29], // robolectric does not support 30, yet
+    application = TestApp::class
+)
 class MetadataManagerTest {
 
     private val context: Context = mockk()

--- a/app/src/test/java/com/stevesoltys/seedvault/plugins/saf/DocumentFileTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/plugins/saf/DocumentFileTest.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.provider.DocumentsContract
 import androidx.documentfile.provider.DocumentFile
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stevesoltys.seedvault.TestApp
 import io.mockk.mockk
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -15,7 +16,10 @@ import org.koin.core.context.stopKoin
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [29]) // robolectric does not support 30, yet
+@Config(
+    sdk = [29], // robolectric does not support 30, yet
+    application = TestApp::class
+)
 internal class DocumentFileTest {
 
     private val context: Context = mockk()

--- a/app/src/test/java/com/stevesoltys/seedvault/restore/install/DeviceInfoTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/restore/install/DeviceInfoTest.kt
@@ -6,6 +6,7 @@ import android.util.DisplayMetrics
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stevesoltys.seedvault.R
+import com.stevesoltys.seedvault.TestApp
 import com.stevesoltys.seedvault.getRandomString
 import io.mockk.every
 import io.mockk.mockk
@@ -20,7 +21,10 @@ import org.robolectric.annotation.Config
 import kotlin.random.Random
 
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [29]) // robolectric does not support 30, yet
+@Config(
+    sdk = [29], // robolectric does not support 30, yet
+    application = TestApp::class
+)
 internal class DeviceInfoTest {
 
     @After


### PR DESCRIPTION
This PR is a preparation for storage backup. It uses the remaining 256 bits of the 512 bits that fall out of the BIP39 recovery code to store a main key in Android's key store that we can use to derive further keys from. The original key was locked down too much to be used for that.

When a new recovery code is created or an existing one is verified, the main key will be stored. This allows for getting a main key also for existing installs.

Simple tests for `KeyManagerImpl` were added and a `TestApp` introduced, so we can use different modules in tests.