### PR TITLE
Improve recovery code output fragment's wordlist layout

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/ui/recoverycode/RecoveryCodeOutputFragment.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/recoverycode/RecoveryCodeOutputFragment.kt
@@ -45,7 +45,7 @@ class RecoveryCodeOutputFragment : Fragment() {
     private fun setGridParameters(list: RecyclerView) {
         val layoutManager = list.layoutManager as GridLayoutManager
         if (resources.configuration.orientation == ORIENTATION_LANDSCAPE) {
-            layoutManager.spanCount = 4
+            layoutManager.spanCount = 3
         } else {
             layoutManager.spanCount = 2
         }

--- a/app/src/main/res/layout/fragment_recovery_code_output.xml
+++ b/app/src/main/res/layout/fragment_recovery_code_output.xml
@@ -56,10 +56,12 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/wordList"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:orientation="vertical"
+        android:scrollbars="vertical"
         app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+        app:layout_constrainedHeight="true"
         app:layout_constraintBottom_toTopOf="@+id/confirmCodeButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/list_item_recovery_code_output.xml
+++ b/app/src/main/res/layout/list_item_recovery_code_output.xml
@@ -2,15 +2,15 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:layout_height="80dp"
     android:padding="24dp"
     tools:showIn="@layout/fragment_recovery_code_output">
 
     <TextView
         android:id="@+id/num"
         android:layout_width="24dp"
-        android:layout_height="0dp"
+        android:layout_height="match_parent"
         android:gravity="center_vertical|end"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/word"
@@ -22,11 +22,11 @@
 
     <TextView
         android:id="@+id/word"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
         android:layout_marginStart="16dp"
         android:autoSizeTextType="uniform"
-        android:textSize="24sp"
+        android:gravity="center_vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/num"


### PR DESCRIPTION
* Enable scrollbar
* Enable text size autoscalling (min 12sp, max 24sp)
* Fix wordList constraints
* Set wordList height to match_parent so that scrollbar
  our word list will always start from top
* Set wordList width to match_parent so that scrollbar
  is displayed on the sides
* Reduce landscape spanCount to 3 so that we'll be less
  likely to clip the some longer word

Change-Id: I7a2481fe25163f81f6d3c3626784cc4681f7c4ef