### PR TITLE
Disable Nextcloud restore when not installed and no store available

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageRootFetcher.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageRootFetcher.kt
@@ -156,11 +156,19 @@ internal class StorageRootFetcher(private val context: Context, private val isRe
             data = Uri.parse("nc://login/server:")
             putExtra("onlyAdd", true)
         }
+        val marketIntent =
+            Intent(ACTION_VIEW, Uri.parse("market://details?id=$NEXTCLOUD_PACKAGE")).apply {
+                addFlags(FLAG_ACTIVITY_NEW_TASK)
+            }
         val isInstalled = packageManager.resolveActivity(intent, 0) != null
+        val canInstall = packageManager.resolveActivity(marketIntent, 0) != null
         val summaryRes = if (isInstalled) {
             if (isRestore) R.string.storage_fake_nextcloud_summary_installed
             else R.string.storage_fake_nextcloud_summary_unavailable
-        } else R.string.storage_fake_nextcloud_summary
+        } else {
+            if (canInstall) R.string.storage_fake_nextcloud_summary
+            else R.string.storage_fake_nextcloud_summary_unavailable_market
+        }
         val root = StorageRoot(
             authority = AUTHORITY_NEXTCLOUD,
             rootId = "fake",
@@ -171,15 +179,10 @@ internal class StorageRootFetcher(private val context: Context, private val isRe
             availableBytes = null,
             isUsb = false,
             requiresNetwork = true,
-            enabled = !isInstalled || isRestore,
+            enabled = isInstalled || canInstall,
             overrideClickListener = {
                 if (isInstalled) context.startActivity(intent)
-                else {
-                    val uri = Uri.parse("market://details?id=$NEXTCLOUD_PACKAGE")
-                    val i = Intent(ACTION_VIEW, uri)
-                    i.addFlags(FLAG_ACTIVITY_NEW_TASK)
-                    context.startActivity(i)
-                }
+                else if (canInstall) context.startActivity(marketIntent)
             }
         )
         roots.add(root)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="storage_fake_nextcloud_summary">Tap to install</string>
     <string name="storage_fake_nextcloud_summary_installed">Tap to set up account</string>
     <string name="storage_fake_nextcloud_summary_unavailable">Account not available. Set one up (or disable passcode).</string>
+    <string name="storage_fake_nextcloud_summary_unavailable_market">Not installed</string>
     <string name="storage_check_fragment_backup_title">Initializing backup location…</string>
     <string name="storage_check_fragment_patience">This may take some time…</string>
     <string name="storage_check_fragment_restore_title">Looking for backups…</string>


### PR DESCRIPTION
Attempting to install Nextcloud in SetupWizard on a device
that has no app store installed results in a crash.
Disable the option and use an appropriate summary.

Change-Id: Ie3dff8d85ed68b27858fa37b3efb97eb345fa372