### PR TITLE
Link FAQ in Readme to make it more discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 A backup application for the [Android Open Source Project](https://source.android.com/).
 
+If you are having an issue/question, please look at our [FAQ](../../wiki/FAQ).
+
 ## Components
 
 * [Local Contacts Backup](contactsbackup) - an app that backs up local on-device contacts


### PR DESCRIPTION
E.g. for https://github.com/seedvault-app/seedvault/issues/264 I found the FAQ way to late.

And for users this is a very valuable resource. As such, IMHO you should make it more discoverable, e.g. like this.