### PR TITLE
Allow launching restore through a dialer code

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -116,6 +116,15 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".SecretCodeReceiver">
+            <intent-filter>
+                <action android:name="android.telephony.action.SECRET_CODE" />
+                <!-- *#*#RESTORE#*#* -->
+                <data android:scheme="android_secret_code" android:host="7378673" />
+            </intent-filter>
+        </receiver>
+
         <!-- Used to start actual BackupService depending on scheduling criteria -->
         <service
             android:name=".storage.StorageBackupJobService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,16 @@
     <!-- Used to authenticate saving a new recovery code -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
+    <!-- Permission used to open settings -->
+    <permission
+        android:name="com.stevesoltys.seedvault.OPEN_SETTINGS"
+        android:protectionLevel="system|signature" />
+
+    <!-- Permission used to open backup gui -->
+    <permission
+        android:name="com.stevesoltys.seedvault.RESTORE_BACKUP"
+        android:protectionLevel="system|signature" />
+
     <application
         android:name=".App"
         android:allowBackup="false"
@@ -62,6 +72,7 @@
 
         <activity
             android:name=".settings.SettingsActivity"
+            android:permission="com.stevesoltys.seedvault.OPEN_SETTINGS"
             android:exported="true" />
 
         <activity
@@ -80,6 +91,7 @@
 
         <activity
             android:name=".restore.RestoreActivity"
+            android:permission="com.stevesoltys.seedvault.RESTORE_BACKUP"
             android:exported="true"
             android:label="@string/restore_title"
             android:theme="@style/AppTheme.NoActionBar">

--- a/app/src/main/java/com/stevesoltys/seedvault/SecretCodeReceiver.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/SecretCodeReceiver.kt
@@ -1,0 +1,24 @@
+package com.stevesoltys.seedvault
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import android.util.Log
+import com.stevesoltys.seedvault.restore.RestoreActivity
+
+private val TAG = BroadcastReceiver::class.java.simpleName
+private val RESTORE_SECRET_CODE = "7378673"
+
+class SecretCodeReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val host = intent.data.host
+        if (!RESTORE_SECRET_CODE.equals(host)) return
+        Log.d(TAG, "Restore secret code received.")
+        val i = Intent(context, RestoreActivity::class.java).apply {
+            flags = FLAG_ACTIVITY_NEW_TASK
+        }
+        context.startActivity(i)
+    }
+}


### PR DESCRIPTION
* We don't show Restore in menu by default since it's
  not the best idea to restore a running system
* However, at the same time, it's good to have a way to do
  that for those who'd like to restore anyway, and the only
  current way is adb, which is not ideal
* Dialing "*#*#RESTORE#*#*" will launch the restore activity

Change-Id: I258fead82f7e916a4de0b314e1840d7aa4b3746c