### PR TITLE
Don't delete anything when SAF renaming fails

### DIFF
--- a/core/src/main/java/org/calyxos/seedvault/core/backends/saf/SafBackend.kt
+++ b/core/src/main/java/org/calyxos/seedvault/core/backends/saf/SafBackend.kt
@@ -221,7 +221,6 @@ public class SafBackend(
         val toFile = DocumentFile.fromTreeUri(context, newUri)
             ?: throw IOException("renamed URI invalid: $newUri")
         if (toFile.name != toName) {
-            toFile.delete()
             throw IOException("renamed to ${toFile.name}, but expected $toName")
         }
     }


### PR DESCRIPTION
SAF is a mess and when renaming fails we don't know for sure what happened, so to be on the safe side, better not to delete anything, so it may be recovered by the user.