### PR TITLE
fix(webdav): skip Nextcloud trashbin for backup cleanup

### DIFF
--- a/core/src/main/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackend.kt
+++ b/core/src/main/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackend.kt
@@ -53,6 +53,7 @@ import kotlin.coroutines.suspendCoroutine
 import kotlin.reflect.KClass
 
 private const val DEBUG_LOG = true
+private val DELETE_HEADERS = mapOf("X-NC-Skip-Trashbin" to "true")
 
 public class WebDavBackend(
     webDavConfig: WebDavConfig,
@@ -304,7 +305,7 @@ public class WebDavBackend(
 
         try {
             val response = suspendCoroutine { cont ->
-                davCollection.delete { response ->
+                davCollection.delete(headers = DELETE_HEADERS) { response ->
                     cont.resume(response)
                 }
             }
@@ -345,7 +346,7 @@ public class WebDavBackend(
         val location = "$url/".toHttpUrl()
         val davCollection = DavCollection(okHttpClient, location)
         try {
-            davCollection.delete { response ->
+            davCollection.delete(headers = DELETE_HEADERS) { response ->
                 log.debugLog { "removeAll() = $response" }
             }
         } catch (e: NotFoundException) {

--- a/core/src/test/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackendTest.kt
+++ b/core/src/test/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackendTest.kt
@@ -5,53 +5,13 @@
 
 package org.calyxos.seedvault.core.backends.webdav
 
-import at.bitfire.dav4jvm.okhttp.DavCollection
-import at.bitfire.dav4jvm.okhttp.ResponseCallback
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkConstructor
-import io.mockk.unmockkConstructor
 import kotlinx.coroutines.runBlocking
 import org.calyxos.seedvault.core.backends.Backend
 import org.calyxos.seedvault.core.backends.BackendTest
-import org.calyxos.seedvault.core.backends.TopLevelFolder
 import org.junit.Test
-import kotlin.test.assertEquals
 
 internal class WebDavBackendTest : BackendTest() {
-    override val backend: Backend by lazy {
-        WebDavBackend(WebDavTestConfig.getConfig(), ".SeedvaultTest")
-    }
-
-    @Test
-    fun `delete requests skip the Nextcloud trashbin`(): Unit = runBlocking {
-        val headers = mutableListOf<Map<String, String>>()
-        mockkConstructor(DavCollection::class)
-        every {
-            anyConstructed<DavCollection>().delete(
-                ifETag = null,
-                ifScheduleTag = null,
-                headers = capture(headers),
-                callback = any(),
-            )
-        } answers {
-            arg<ResponseCallback>(3).onResponse(mockk(relaxed = true))
-        }
-
-        try {
-            val backend = WebDavBackend(
-                WebDavConfig("https://example.com", "user", "password"),
-                ".SeedvaultTest",
-            )
-            backend.remove(TopLevelFolder("folder"))
-            backend.removeAll()
-        } finally {
-            unmockkConstructor(DavCollection::class)
-        }
-
-        val expected = mapOf("X-NC-Skip-Trashbin" to "true")
-        assertEquals(listOf(expected, expected), headers)
-    }
+    override val backend: Backend = WebDavBackend(WebDavTestConfig.getConfig(), ".SeedvaultTest")
 
     @Test
     fun `test write, list, read, rename, delete`(): Unit = runBlocking {

--- a/core/src/test/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackendTest.kt
+++ b/core/src/test/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackendTest.kt
@@ -5,13 +5,53 @@
 
 package org.calyxos.seedvault.core.backends.webdav
 
+import at.bitfire.dav4jvm.okhttp.DavCollection
+import at.bitfire.dav4jvm.okhttp.ResponseCallback
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
 import kotlinx.coroutines.runBlocking
 import org.calyxos.seedvault.core.backends.Backend
 import org.calyxos.seedvault.core.backends.BackendTest
+import org.calyxos.seedvault.core.backends.TopLevelFolder
 import org.junit.Test
+import kotlin.test.assertEquals
 
 internal class WebDavBackendTest : BackendTest() {
-    override val backend: Backend = WebDavBackend(WebDavTestConfig.getConfig(), ".SeedvaultTest")
+    override val backend: Backend by lazy {
+        WebDavBackend(WebDavTestConfig.getConfig(), ".SeedvaultTest")
+    }
+
+    @Test
+    fun `delete requests skip the Nextcloud trashbin`(): Unit = runBlocking {
+        val headers = mutableListOf<Map<String, String>>()
+        mockkConstructor(DavCollection::class)
+        every {
+            anyConstructed<DavCollection>().delete(
+                ifETag = null,
+                ifScheduleTag = null,
+                headers = capture(headers),
+                callback = any(),
+            )
+        } answers {
+            arg<ResponseCallback>(3).onResponse(mockk(relaxed = true))
+        }
+
+        try {
+            val backend = WebDavBackend(
+                WebDavConfig("https://example.com", "user", "password"),
+                ".SeedvaultTest",
+            )
+            backend.remove(TopLevelFolder("folder"))
+            backend.removeAll()
+        } finally {
+            unmockkConstructor(DavCollection::class)
+        }
+
+        val expected = mapOf("X-NC-Skip-Trashbin" to "true")
+        assertEquals(listOf(expected, expected), headers)
+    }
 
     @Test
     fun `test write, list, read, rename, delete`(): Unit = runBlocking {

--- a/core/src/test/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackendUnitTest.kt
+++ b/core/src/test/java/org/calyxos/seedvault/core/backends/webdav/WebDavBackendUnitTest.kt
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2024 The Calyx Institute
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.calyxos.seedvault.core.backends.webdav
+
+import at.bitfire.dav4jvm.okhttp.DavCollection
+import at.bitfire.dav4jvm.okhttp.ResponseCallback
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import kotlinx.coroutines.runBlocking
+import org.calyxos.seedvault.core.backends.TopLevelFolder
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class WebDavBackendUnitTest {
+
+    @Test
+    fun `delete requests skip the Nextcloud trashbin`(): Unit = runBlocking {
+        val headers = mutableListOf<Map<String, String>>()
+        mockkConstructor(DavCollection::class)
+        every {
+            anyConstructed<DavCollection>().delete(
+                ifETag = null,
+                ifScheduleTag = null,
+                headers = capture(headers),
+                callback = any(),
+            )
+        } answers {
+            arg<ResponseCallback>(3).onResponse(mockk(relaxed = true))
+        }
+
+        try {
+            val backend = WebDavBackend(
+                WebDavConfig("https://example.com", "user", "password"),
+                ".SeedvaultTest",
+            )
+            backend.remove(TopLevelFolder("folder"))
+            backend.removeAll()
+        } finally {
+            unmockkConstructor(DavCollection::class)
+        }
+
+        val expected = mapOf("X-NC-Skip-Trashbin" to "true")
+        assertEquals(listOf(expected, expected), headers)
+    }
+}


### PR DESCRIPTION
Closes #1037

## Summary

- Send `X-NC-Skip-Trashbin: true` with WebDAV cleanup DELETE requests.
- Cover both individual and whole-backup deletion paths with a focused unit test.

## Validation

- `:core:testDebugUnitTest --tests '*WebDavBackendTest*'`
- `:core:check :core:assemble :core:ktlintCheck`
