### PR TITLE
Warn when Backup now has nothing selected to back up

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsFragment.kt
@@ -15,6 +15,7 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
 import android.widget.Toast.LENGTH_LONG
+import androidx.annotation.StringRes
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
@@ -202,21 +203,25 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private fun onMenuItemSelected(item: MenuItem): Boolean = when (item.itemId) {
         R.id.action_backup -> {
-            viewModel.backupNow()
-            lifecycleScope.launch {
-                val canDoBackupNow = withContext(Dispatchers.IO) {
-                    backendManager.canDoBackupNow()
-                }
-                if (!canDoBackupNow) withContext(Dispatchers.Main) {
-                    // if USB isn't plugged in, this action shouldn't be enabled,
-                    // so this leaves only that we are on a metered network
-                    MaterialAlertDialogBuilder(requireContext())
-                        .setTitle(getString(R.string.settings_backup_metered_title))
-                        .setMessage(getString(R.string.settings_backup_metered_text))
-                        .setNeutralButton(getString(R.string.restore_storage_got_it)) { dialog, _ ->
-                            dialog.dismiss()
-                        }
-                        .show()
+            if (!backup.isChecked && !backupStorage.isChecked) {
+                showBackupInfoDialog(
+                    R.string.settings_backup_nothing_selected_title,
+                    R.string.settings_backup_nothing_selected_text,
+                )
+            } else {
+                viewModel.backupNow()
+                lifecycleScope.launch {
+                    val canDoBackupNow = withContext(Dispatchers.IO) {
+                        backendManager.canDoBackupNow()
+                    }
+                    if (!canDoBackupNow) withContext(Dispatchers.Main) {
+                        // if USB isn't plugged in, this action shouldn't be enabled,
+                        // so this leaves only that we are on a metered network
+                        showBackupInfoDialog(
+                            R.string.settings_backup_metered_title,
+                            R.string.settings_backup_metered_text,
+                        )
+                    }
                 }
             }
             true
@@ -240,6 +245,16 @@ class SettingsFragment : PreferenceFragmentCompat() {
             true
         }
         else -> false
+    }
+
+    private fun showBackupInfoDialog(@StringRes title: Int, @StringRes text: Int) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(getString(title))
+            .setMessage(getString(text))
+            .setNeutralButton(getString(R.string.restore_storage_got_it)) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .show()
     }
 
     private fun trySetBackupEnabled(enabled: Boolean): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,8 @@
     <string name="settings_backup_new_code_code_dialog_ok">New code</string>
     <string name="settings_backup_metered_title">Backup stopped</string>
     <string name="settings_backup_metered_text">The backup won\'t proceed because your device is using mobile data.\n\nYou can enable backups on mobile data under \"Backup scheduling\".</string>
+    <string name="settings_backup_nothing_selected_title">Nothing to back up</string>
+    <string name="settings_backup_nothing_selected_text">You haven\'t selected anything to back up.\n\nTurn on \"Backup my apps\" or \"Backup my files\" first.</string>
 
 
     <string name="settings_scheduling_frequency_title">Backup frequency</string>


### PR DESCRIPTION
Fixes #1041.

## What's happening today
If both "Backup my apps" and "Backup my files" are turned off, pressing "Backup now" silently does nothing — no error, no toast, no indication that anything is wrong. That's what was reported in the linked discussion (#1033): a user configured a storage location but hadn't enabled either backup type, pressed "Backup now", and got no feedback at all.

## Fix
Before triggering a backup, check whether at least one of `backup` (app backup) or `backupStorage` (file backup) is enabled. If neither is on, show a dialog explaining that nothing is selected, instead of silently doing nothing.

To avoid duplicating the dialog-building code, I pulled the existing "metered network" warning dialog (which already covers a similar "backup didn't run, here's why" case) out into a small `showBackupInfoDialog()` helper and reused it for both cases.

## Scope
This covers the manual "Backup now" path, which is the symptom described in the issue. The issue also mentions a user enabling *scheduled* backups and expecting them to work with defaults — that path isn't touched here. Happy to follow up on it separately if you'd like it in the same change.

## Testing
- `./gradlew :app:compileDebugKotlin` — passes
- `./gradlew :app:processDebugResources` — passes (new strings valid)
- `./gradlew :app:ktlintCheck` — passes
- Manually reasoned through both branches (nothing selected vs. metered network) since I don't have a device handy to run this on right now — happy to add a screenshot if that's wanted before merge.
