### PR TITLE
Migrate instrumentation tests to GitHub Actions

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -10,8 +10,12 @@ echo "Installing Seedvault app..."
 ./gradlew --stacktrace :app:installDebugAndroidTest
 sleep 60
 
+# The large tests (the app's end-to-end backup/restore test) are run on their
+# own via the instrumentation runner's built-in size filtering.
 large_test_exit_code=0
-./gradlew --stacktrace -Pinstrumented_test_size=large :app:connectedAndroidTest || large_test_exit_code=$?
+./gradlew --stacktrace \
+    -Pandroid.testInstrumentationRunnerArguments.size=large \
+    :app:connectedAndroidTest || large_test_exit_code=$?
 
 adb pull /sdcard/seedvault_test_results
 
@@ -20,11 +24,14 @@ if [ "$large_test_exit_code" -ne 0 ]; then
     exit 1
 fi
 
-medium_test_exit_code=0
-./gradlew --stacktrace -Pinstrumented_test_size=medium :app:connectedAndroidTest || medium_test_exit_code=$?
+# All remaining (non-large) instrumentation tests across every module.
+other_test_exit_code=0
+./gradlew --stacktrace \
+    -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.LargeTest \
+    connectedAndroidTest || other_test_exit_code=$?
 
-if [ "$medium_test_exit_code" -ne 0 ]; then
-    echo 'Medium tests failed.'
+if [ "$other_test_exit_code" -ne 0 ]; then
+    echo 'Non-large tests failed.'
     exit 1
 fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - android*
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,51 +12,61 @@ concurrency:
 
 jobs:
   instrumentation_tests:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     if: github.repository == 'seedvault-app/seedvault'
     timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:
         android_target: [ 34 ]
-        emulator_type: [ aosp_atd ]
+        emulator_type: [ default ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      # The emulator needs KVM hardware acceleration to run at a usable speed on
+      # ubuntu-latest runners.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '17'
+          distribution: 'corretto'
+          java-version: 21
           cache: 'gradle'
 
-      - name: Build Release APK
-        run: ./gradlew :app:assembleRelease
+      # Seedvault and ContactsBackup are installed as system priv-apps during
+      # provisioning, so both release APKs need to be built up front.
+      - name: Build Release APKs
+        run: ./gradlew :app:assembleRelease :contactsbackup:assembleRelease
 
       - name: Assemble tests
-        run: ./gradlew :app:assembleAndroidTest
+        run: ./gradlew assembleAndroidTest
 
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: reactivecircus/android-emulator-runner@v2
         with:
-          attempt_limit: 1
-          action: reactivecircus/android-emulator-runner@v2
-          with: |
-            api-level: ${{ matrix.android_target }}
-            target: ${{ matrix.emulator_type }}
-            arch: x86_64
-            force-avd-creation: true
-            emulator-options: -cores 2 -writable-system -no-snapshot-load -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-            disk-size: '14G'
-            sdcard-path-or-size: '4096M'
-            disable-animations: true
-            script: |
-              ./app/development/scripts/provision_emulator.sh "test" "system-images;android-${{ matrix.android_target }};${{ matrix.emulator_type }};x86_64"
-              ./.github/scripts/run_tests.sh
+          api-level: ${{ matrix.android_target }}
+          target: ${{ matrix.emulator_type }}
+          arch: x86_64
+          force-avd-creation: true
+          emulator-options: -cores 2 -writable-system -no-snapshot-load -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disk-size: '14G'
+          sdcard-path-or-size: '4096M'
+          disable-animations: true
+          script: |
+            ./app/development/scripts/provision_emulator.sh "test" "system-images;android-${{ matrix.android_target }};${{ matrix.emulator_type }};x86_64"
+            ./.github/scripts/run_tests.sh
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.emulator_type }}-${{ matrix.android_target }}-results
-          path: seedvault_test_results/**/*
+          path: |
+            seedvault_test_results/**/*
+            **/build/reports/**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,13 @@ android {
         resources {
             excludes += listOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md")
         }
+        // Some androidTest dependencies (e.g. mockk-android) ship native libs
+        // with extractNativeLibs="true" in their manifest, which current AGP
+        // rejects when packaging the androidTest APK unless we opt into legacy
+        // packaging here (as :contactsbackup already does).
+        jniLibs {
+            useLegacyPackaging = true
+        }
     }
 
     testOptions.unitTests {

--- a/app/development/scripts/install_app.sh
+++ b/app/development/scripts/install_app.sh
@@ -33,4 +33,12 @@ $ADB push "$ROOT_PROJECT_DIR"/app/build/outputs/apk/release/app-release.apk /sys
 echo "Installing Seedvault permissions..."
 $ADB push "$ROOT_PROJECT_DIR"/permissions_com.stevesoltys.seedvault.xml /system/etc/permissions/privapp-permissions-seedvault.xml
 $ADB push "$ROOT_PROJECT_DIR"/allowlist_com.stevesoltys.seedvault.xml /system/etc/sysconfig/allowlist-seedvault.xml
+
+echo "Installing ContactsBackup app..."
+$ADB shell mkdir -p /system/priv-app/ContactsBackup
+$ADB push "$ROOT_PROJECT_DIR"/contactsbackup/build/outputs/apk/release/contactsbackup-release.apk /system/priv-app/ContactsBackup/ContactsBackup.apk
+
+echo "Installing ContactsBackup permissions..."
+$ADB push "$ROOT_PROJECT_DIR"/contactsbackup/default-permissions_org.calyxos.backup.contacts.xml /system/etc/default-permissions/default-permissions_org.calyxos.backup.contacts.xml
+
 $ADB shell am broadcast -a android.intent.action.BOOT_COMPLETED


### PR DESCRIPTION
Cirrus CI no longer works and was removed, so the instrumentation tests haven't been running anywhere. Move them back to GitHub Actions.